### PR TITLE
batch cropping for 2D

### DIFF
--- a/examples/time_cropping.py
+++ b/examples/time_cropping.py
@@ -1,0 +1,43 @@
+import torch
+import time
+from contextlib import contextmanager
+from torch_subpixel_crop import subpixel_crop_2d
+
+@contextmanager
+def timer(name: str):
+    """Simple timing context manager.
+    
+    Parameters
+    ----------
+    name : str
+        Name to display for this timing section.
+    """
+    torch.cuda.synchronize()  # Wait for GPU operations to finish
+    start = time.perf_counter()
+    yield
+    torch.cuda.synchronize()  # Wait for GPU operations to finish
+    elapsed = time.perf_counter() - start
+    print(f"{name}: {elapsed*1000:.2f} ms")
+
+
+# Test setup
+device = 'cuda'
+batch_size = 40
+image_size = 512
+patch_size = 96
+
+# Create test data
+images = torch.randn(batch_size, image_size, image_size, device=device)
+positions = torch.rand(batch_size, 2, device=device) * image_size
+
+# Warmup (important for accurate GPU timing!)
+for _ in range(5):
+    _ = subpixel_crop_2d(images, positions, patch_size)
+
+# Time it
+n_runs = 100
+with timer(f"subpixel_crop_2d ({n_runs} runs)"):
+    for _ in range(n_runs):
+        patches = subpixel_crop_2d(images, positions, patch_size)
+
+print(f"Output shape: {patches.shape}")

--- a/examples/time_cropping.py
+++ b/examples/time_cropping.py
@@ -24,7 +24,7 @@ def timer(name: str):
 device = 'cuda'
 batch_size = 40
 n_positions = 4
-image_size = 2048
+image_size = 4096
 patch_size = 96
 
 # Create test data

--- a/examples/time_cropping.py
+++ b/examples/time_cropping.py
@@ -23,12 +23,13 @@ def timer(name: str):
 # Test setup
 device = 'cuda'
 batch_size = 40
-image_size = 512
+n_positions = 4
+image_size = 2048
 patch_size = 96
 
 # Create test data
 images = torch.randn(batch_size, image_size, image_size, device=device)
-positions = torch.rand(batch_size, 2, device=device) * image_size
+positions = torch.rand(n_positions, batch_size, 2, device=device) * image_size
 
 # Warmup (important for accurate GPU timing!)
 for _ in range(5):

--- a/src/torch_subpixel_crop/subpixel_crop_2d.py
+++ b/src/torch_subpixel_crop/subpixel_crop_2d.py
@@ -9,32 +9,28 @@ from torch_subpixel_crop.grid_sample_utils import array_to_grid_sample
 
 
 def subpixel_crop_2d(
-    image: torch.Tensor, positions: torch.Tensor, sidelength: int,
+        image: torch.Tensor,
+        positions: torch.Tensor,
+        sidelength: int,
 ):
     """Extract square patches from 2D images with subpixel precision.
 
-    Patches are extracted at the nearest integer coordinates then phase shifted
-    such that the requested position is at the center of the patch.
-
-    The center of an image is defined to be the position of the DC component of an
-    fftshifted discrete Fourier transform.
-
     Parameters
     ----------
-    image: torch.Tensor
+    image : torch.Tensor
         `(b, h, w)` or `(h, w)` array of 2D images.
-    positions: torch.Tensor
+    positions : torch.Tensor
         `(..., b, 2)` or `(..., 2)` array of coordinates for patch centers.
-    sidelength: int
+    sidelength : int
         Sidelength of square patches extracted from `images`.
 
     Returns
     -------
-    patches: torch.Tensor
-        `(..., b, sidelength, sidelength)` or `(..., sidelength, sidelength)` array
-         of patches from `image` with their centers at `positions`.
+    patches : torch.Tensor
+        `(..., b, sidelength, sidelength)` or `(..., sidelength, sidelength)`
+        array of patches.
     """
-    # handling batched input
+    # Handle unbatched input
     if image.ndim == 2:
         input_images_are_batched = False
         image = einops.rearrange(image, 'h w -> 1 h w')
@@ -42,62 +38,85 @@ def subpixel_crop_2d(
     else:
         input_images_are_batched = True
 
-    # setup coordinates and extract
-    positions, ps = einops.pack([positions], pattern='* t yx')
-    positions = einops.rearrange(positions, 'b t yx -> t b yx')
-    patches = einops.rearrange(
-        [
-            _extract_patches_from_single_image(
-                image=_image,
-                positions=_positions,
-                output_image_sidelength=sidelength
-            )
-            for _image, _positions
-            in zip(image, positions)
-        ],
-        pattern='t b h w -> b t h w'
-    )
-    [patches] = einops.unpack(patches, pattern='* t h w', packed_shapes=ps)
+    # Flatten batch dimensions
+    positions, ps = einops.pack([positions], pattern='* batch yx')
 
-    # unbatch output if input images weren't batched
-    if input_images_are_batched is False:
-        patches = einops.rearrange(patches, pattern='... 1 h w -> ... h w')
+    # Process ALL images at once (no loop!)
+    patches = _extract_patches_batched(
+        images=image,  # (batch, h, w)
+        positions=positions,  # (n_positions, batch, 2)
+        output_image_sidelength=sidelength
+    )
+
+    # Restore original shape
+    [patches] = einops.unpack(patches, pattern='* batch h w', packed_shapes=ps)
+
+    if not input_images_are_batched:
+        patches = einops.rearrange(patches, '... 1 h w -> ... h w')
+
     return patches
 
 
-def _extract_patches_from_single_image(
-    image: torch.Tensor,  # (h, w)
-    positions: torch.Tensor,  # (b, 2) yx
-    output_image_sidelength: int,
-) -> torch.Tensor:
-    h, w = image.shape
-    b, _ = positions.shape
+def _extract_patches_batched(
+        images: torch.Tensor,  # (batch, h, w)
+        positions: torch.Tensor,  # (n_positions, batch, 2) yx
+        output_image_sidelength: int,
+) -> torch.Tensor:  # (n_positions, batch, ph, pw)
+    batch, h, w = images.shape
+    n_positions, batch_check, _ = positions.shape
+    assert batch == batch_check
 
-    # find integer positions and shifts to be applied
+    # Find integer positions and shifts
     integer_positions = torch.round(positions)
-    shifts = integer_positions - positions
+    shifts = integer_positions - positions  # (n_positions, batch, 2)
 
-    # generate coordinate grids for sampling around each integer position
-    ph, pw = (output_image_sidelength, output_image_sidelength)
-    center = dft_center((ph, pw), rfft=False, fftshifted=True, device=image.device)
+    # Generate coordinate grid
+    ph = pw = output_image_sidelength
+    center = dft_center((ph, pw), rfft=False, fftshifted=True,
+                        device=images.device)
     grid = coordinate_grid(
         image_shape=(ph, pw),
         center=center,
-        device=image.device
-    )  # (h, w, 2)
-    broadcastable_positions = einops.rearrange(integer_positions, 'b yx -> b 1 1 yx')
-    grid = grid + broadcastable_positions  # (b, h, w, 2)
+        device=images.device
+    )  # (ph, pw, 2)
 
-    # extract patches, grid sample handles boundaries
+    # Broadcast grid for all positions and batches
+    grid = einops.rearrange(grid, 'ph pw yx -> 1 1 ph pw yx')
+    integer_positions = einops.rearrange(
+        integer_positions, 'n_pos batch yx -> n_pos batch 1 1 yx'
+    )
+    grid = grid + integer_positions  # (n_pos, batch, ph, pw, 2)
+
+    # Flatten for grid_sample
+    grid_flat = einops.rearrange(grid,
+                                 'n_pos batch ph pw yx -> (n_pos batch) ph pw yx')
+    images_repeated = einops.repeat(
+        images, 'batch h w -> (n_pos batch) 1 h w', n_pos=n_positions
+    )
+
+    # Extract all patches at once
     patches = F.grid_sample(
-        input=einops.repeat(image, 'h w -> b 1 h w', b=b),
-        grid=array_to_grid_sample(grid, array_shape=(h, w)),
+        input=images_repeated,
+        grid=array_to_grid_sample(grid_flat, array_shape=(h, w)),
         mode='nearest',
         padding_mode='zeros',
         align_corners=True
-    )
-    patches = einops.rearrange(patches, 'b 1 h w -> b h w')
+    )  # (n_pos * batch, 1, ph, pw)
 
-    # phase shift to center images
-    patches = fourier_shift_image_2d(image=patches, shifts=shifts)
+    patches = einops.rearrange(
+        patches, '(n_pos batch) 1 ph pw -> (n_pos batch) ph pw',
+        n_pos=n_positions, batch=batch
+    )
+
+    # Phase shift all at once
+    shifts_flat = einops.rearrange(shifts,
+                                   'n_pos batch yx -> (n_pos batch) yx')
+    patches = fourier_shift_image_2d(image=patches, shifts=shifts_flat)
+
+    # Reshape to output
+    patches = einops.rearrange(
+        patches, '(n_pos batch) ph pw -> n_pos batch ph pw',
+        n_pos=n_positions, batch=batch
+    )
+
     return patches

--- a/src/torch_subpixel_crop/subpixel_crop_2d.py
+++ b/src/torch_subpixel_crop/subpixel_crop_2d.py
@@ -110,7 +110,6 @@ def _extract_patches_batched(
         padding_mode='zeros',
         align_corners=True
     )  # (batch, 1, n_pos, ph, pw)
-    print(patches.shape)
 
     # can these be combined
     patches = einops.rearrange(

--- a/src/torch_subpixel_crop/subpixel_crop_2d.py
+++ b/src/torch_subpixel_crop/subpixel_crop_2d.py
@@ -111,21 +111,10 @@ def _extract_patches_batched(
         align_corners=True
     )  # (batch, 1, n_pos, ph, pw)
 
-    # can these be combined
+    # rearrange to correct order
     patches = einops.rearrange(
-        patches, 'batch 1 n_pos ph pw -> (n_pos batch) ph pw',
+        patches, 'batch 1 n_pos ph pw -> n_pos batch ph pw',
     )
-
-    # Phase shift all at once
-    shifts_flat = einops.rearrange(
-        shifts, 'n_pos batch yx -> (n_pos batch) yx'
-    )
-    patches = fourier_shift_image_2d(image=patches, shifts=shifts_flat)
-
-    # Reshape to output
-    patches = einops.rearrange(
-        patches, '(n_pos batch) ph pw -> n_pos batch ph pw',
-        n_pos=n_pos, batch=batch,
-    )
+    patches = fourier_shift_image_2d(image=patches, shifts=shifts)
 
     return patches

--- a/tests/test_subpixel_crop_2d.py
+++ b/tests/test_subpixel_crop_2d.py
@@ -1,5 +1,6 @@
 import torch
 import einops
+import pytest
 
 from torch_subpixel_crop import subpixel_crop_2d
 
@@ -42,13 +43,23 @@ def test_subpixel_crop_multi_2d():
 
 def test_subpixel_crop_multi_batch_2d():
     batch = 3
-    image = torch.zeros((batch, 10, 10))
-    image[..., 4:6, 4:6] = 1
-
     positions = einops.repeat(
         torch.tensor([[4, 4], [5, 5]]).float(),
         'n yx -> n b yx', b=batch
     )
+
+    image = torch.zeros((2, 10, 10))
+    with pytest.raises(ValueError):
+        # mismatch in image and position batch should raise error
+        cropped_image = subpixel_crop_2d(
+            image=image,
+            positions=positions,
+            sidelength=4
+        )
+
+    image = torch.zeros((batch, 10, 10))
+    image[..., 4:6, 4:6] = 1
+
     cropped_image = subpixel_crop_2d(
         image=image,
         positions=positions,

--- a/tests/test_subpixel_crop_2d.py
+++ b/tests/test_subpixel_crop_2d.py
@@ -1,4 +1,5 @@
 import torch
+import einops
 
 from torch_subpixel_crop import subpixel_crop_2d
 
@@ -36,4 +37,29 @@ def test_subpixel_crop_multi_2d():
 
     expected_1 = torch.zeros((4, 4))
     expected_1[1:3, 1:3] = 1
+    assert torch.allclose(cropped_image[1], expected_1)
+
+
+def test_subpixel_crop_multi_batch_2d():
+    batch = 3
+    image = torch.zeros((batch, 10, 10))
+    image[..., 4:6, 4:6] = 1
+
+    positions = einops.repeat(
+        torch.tensor([[4, 4], [5, 5]]).float(),
+        'n yx -> n b yx', b=batch
+    )
+    cropped_image = subpixel_crop_2d(
+        image=image,
+        positions=positions,
+        sidelength=4
+    )
+    assert cropped_image.shape == (2, 3, 4, 4)
+
+    expected_0 = torch.zeros((3, 4, 4))
+    expected_0[:, 2:4, 2:4] = 1
+    assert torch.allclose(cropped_image[0], expected_0)
+
+    expected_1 = torch.zeros((3, 4, 4))
+    expected_1[:, 1:3, 1:3] = 1
     assert torch.allclose(cropped_image[1], expected_1)

--- a/tests/test_subpixel_crop_2d.py
+++ b/tests/test_subpixel_crop_2d.py
@@ -46,7 +46,8 @@ def test_subpixel_crop_multi_batch_2d():
     positions = einops.repeat(
         torch.tensor([[4, 4], [5, 5]]).float(),
         'n yx -> n b yx', b=batch
-    )
+    ).contiguous()  # clone so that we don't get a view
+    positions[0, 0, 0] = 1  # change one of them to test if it works
 
     image = torch.zeros((2, 10, 10))
     with pytest.raises(ValueError):
@@ -68,7 +69,7 @@ def test_subpixel_crop_multi_batch_2d():
     assert cropped_image.shape == (2, 3, 4, 4)
 
     expected_0 = torch.zeros((3, 4, 4))
-    expected_0[:, 2:4, 2:4] = 1
+    expected_0[1:, 2:4, 2:4] = 1
     assert torch.allclose(cropped_image[0], expected_0)
 
     expected_1 = torch.zeros((3, 4, 4))


### PR DESCRIPTION
I noticed that torch-subpixel-crop was slowing me down when reconstructing patches on GPU. Claude came up with the following implementation to batch over the tilts and positions. The included example got a big speed up. 

* Before the time was: subpixel_crop_2d (100 runs): 1794.35 ms
* Now its: subpixel_crop_2d (100 runs): 90.05 ms

@alisterburt I guess the reason you wrote it like this was because a full tilt-series in GPU memory is quite a lot, but I should say that even on my tiny laptop GPU (4096 MiB) I can still fit a (40, 4096, 4096) tilt series (3310MiB). So I assume this implementation is valid for any GPU.

The GPU occupation can be controlled with the number of 3D positions that should be simultaneously extracted.

still WIP as I need to validate on experimental data whether I get the actual reconstruction, but the tests work